### PR TITLE
Handle PlayerJoinEvent instead or PlayerLoginEvent

### DIFF
--- a/src/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
+++ b/src/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
@@ -37,7 +37,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
@@ -441,7 +441,7 @@ public class BukkitPermissions {
 	protected class PlayerEvents implements Listener {
 
 		@EventHandler(priority = EventPriority.LOWEST)
-		public void onPlayerLogin(PlayerLoginEvent event) {
+		public void onPlayerLogin(PlayerJoinEvent event) {
 
 			
 			


### PR DESCRIPTION
Hello again !
I had an issue : Players always get the default world permission when they were joining the server, and not their current world's permission.
(Here : https://github.com/ElgarL/GroupManager/issues/17 )

This is because the event `PlayerLoginEvent` is the event of first contact to the server, when the player clicks the "Connect" button.
If we use `PlayerJoinEvent` instead, it solve the problem. The is because this event is when the player has successfully logged on the server.

Is it a good idea to use this event instead, or does it create a security issue ?
Thank you in advance for you answer and have a nice day !

PS : I'm really sorry if my english is weird, it isn't my native language.