### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,21 +48,21 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.3-R0.1-SNAPSHOT</version>
+			<version>1.16.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<!--placeholder -->
 		<dependency>
 			<groupId>me.clip</groupId>
 			<artifactId>placeholderapi</artifactId>
-			<version>2.10.4</version>
+			<version>2.10.9</version>
 			<scope>provided</scope>
 		</dependency>
 		<!--bStats -->
 		<dependency>
 			<groupId>org.bstats</groupId>
 			<artifactId>bstats-bukkit</artifactId>
-			<version>1.4</version>
+			<version>1.7</version>
 			<scope>compile</scope>
 		</dependency>
 		<!--Non-Minecraft related dependencies -->
@@ -73,9 +73,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.intellij</groupId>
+			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
-			<version>9.0.4</version>
+			<version>20.1.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/resources/Changelog.txt
+++ b/resources/Changelog.txt
@@ -281,13 +281,11 @@ v2.8:
     - Correct update link when outdated.
     - Catch a VERY rare occurrence of Bukkit returning an OfflinePlayer with no name.
 v2.9:
-    - Bump Spigot-API from 1.16.2 to 1.16.3. (@l1ttleO). 
     - Fix default GlobalGroups.yml. (@ElgarL, @super-cokil, @l1ttleO) 
     - Add Czech translation. (@JetelHudzum)
-    - Fix a really rare error of no world detected when a player logged in due to event ordering. (@ElgarL)
-    - Fix GM creating duplicate user entries due to plugins requesting lookups before GM can process PlayerLoginEvent. (@ElgarL)
-    - Bump junit from 4.11 to 4.13.1 (@dependabot)
-    - Fix syntax for "/temp..." commands (@l1ttleO)
+    - Fix a really rare error of no world detected when a player logged in due to event ordering.
+    - Fix GM creating duplicate user entries due to plugins requesting lookups before GM can process PlayerLoginEvent.
+    - Fix syntax for "/temp..." commands (old commands will still work)
     - Add timed subgroups (@l1ttleO, @ElgarL)
     - Add PAPI support...
         %groupmanager_group%, %groupmanager_allgroups%, %groupmanager_subgroups%,


### PR DESCRIPTION
- Dependency updated: `org.spigotmc.spigotmc-api`: `1.16.3-R0.1-SNAPSHOT` -> `1.16.4-R0.1-SNAPSHOT`
- Dependency updated: `me.clip.placeholderapi`: `2.10.4` -> `2.10.9`
- Dependency updated: `org.bstats.bstats-bukkit`: `1.4` -> `1.7`
- Dependency changed: `com.intellij.annotations` (9.0.4) -> `org.jetbrains.annotations` (20.1.0)
- Also removed useless entries from Changelog.txt