### PR TITLE
Fix markdown in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,26 @@ Ask for assistance in the GroupManager Discord.
 **To include Groupmanager as a dependency in your own plugins.**
 
 Add a repository in your pom.xml
->        <repository>
->            <id>jitpack.io</id>
->            <url>https://jitpack.io</url>
->        </repository>  
+
+```xml
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+```
 Then add as a dependency in your pom.xml
->        <dependency>
->            <groupId>com.github.ElgarL</groupId>
->            <artifactId>groupmanager</artifactId>
->            <version>2.9</version>
->        </dependency>  
+```xml
+        <dependency>
+            <groupId>com.github.ElgarL</groupId>
+            <artifactId>groupmanager</artifactId>
+            <version>2.9</version>
+        </dependency>  
+```
 
 ---
 This sample class can be used in your plugin to access GroupManager.
         
-```
+```java
 import java.util.Arrays;
 import java.util.List;
 
@@ -127,3 +132,4 @@ public class GMHook
 		return handler.has(player, node);
 	}
 }
+```


### PR DESCRIPTION
This PR simply adds Markdown's (or GitHub flavored markdown, but I don't care xD) highlighting to the sample class in the readme, as well as adding this for the `pom.xml` examples, by changing it from 
> quotes 

to `code`. Intentionally targeting the `master` branch.