### PR TITLE
Fixing UTF-8 on french language.

### DIFF
--- a/src/languages/french.properties
+++ b/src/languages/french.properties
@@ -1,116 +1,116 @@
-# Traduction française des messages de propriété.
+# Traduction franÃ§aise des messages de propriÃ©tÃ©.
 # Contributeurs: Gaytis
 
-REMOVED_WORLD_SELECTION=Vous avez supprimé votre sélection de monde. Travaille avec le monde actuel (si possible).
-CREATED_GROUP=Vous avez créé un groupe nommé: %s
-DELETED_GROUP=Vous avez supprimé le groupe nommé %s, ses membres sont désormais membre du groupe par défaut.
+REMOVED_WORLD_SELECTION=Vous avez supprimÃ© votre sÃ©lection de monde. Travaille avec le monde actuel (si possible).
+CREATED_GROUP=Vous avez crÃ©Ã© un groupe nommÃ©: %s
+DELETED_GROUP=Vous avez supprimÃ© le groupe nommÃ© %s, ses membres sont dÃ©sormais membre du groupe par dÃ©faut.
 
-ERROR_GROUP_ALREADY_EXISTS=Le groupe '%s' existe déjà\!
+ERROR_GROUP_ALREADY_EXISTS=Le groupe '%s' existe dÃ©jÃ \!
 ERROR_GROUP_DOES_NOT_EXIST=Le groupe '%s' n'existe pas\!
 ERROR_GG_DO_NOT_SUPPORT_INHERITANCE=GlobalGroups ne supportent pas les parents.
 ERROR_GG_DO_NOT_SUPPORT_INFO_NODES=GlobalGroups ne supporte pas les intersections d'informations.
 ERROR_GROUP_NOT_INHERIT=Groupe %s n'est pas parent de %s.
 ERROR_GROUP_NOT_INHERIT_DIRECT=Groupe %s n'est pas directement parent de %s.
-ERROR_GROUP_ALREADY_INHERITS=Groupe %s hérite déjà de %s (peut-être pas directement).
+ERROR_GROUP_ALREADY_INHERITS=Groupe %s hÃ©rite dÃ©jÃ  de %s (peut-Ãªtre pas directement).
 
-GROUP_NOW_INHERITS=Groupe %s est maintenant dans la liste des héritages de %s.
-GROUP_REMOVED_INHERITANCE=Groupe %s ne fait plus partie de la liste des héritages de %s.
+GROUP_NOW_INHERITS=Groupe %s est maintenant dans la liste des hÃ©ritages de %s.
+GROUP_REMOVED_INHERITANCE=Groupe %s ne fait plus partie de la liste des hÃ©ritages de %s.
 
-ERROR_USER_NO_ACCESS_PERMISSION=Le joueur n'a pas accès à cette permission.
-ERROR_USER_NO_ACCESS_PERMISSION_DIRECT=Le joueur n'a pas d'accès direct à cette permission.
-ERROR_GROUP_NO_ACCESS_PERMISSION=Le groupe n'a pas accès à cette permission.
-ERROR_GROUP_NO_ACCESS_PERMISSION_DIRECT=Le groupe n'a pas d'accès direct à cette permission.
-ERROR_GROUP_NO_ACCESS_VARIABLE=Le groupe n'a pas accès à cette variable\!
-ERROR_GROUP_NO_ACCESS_VARIABLE_DIRECT=Le groupe n'a pas d'accès direct à cette variable\!
-ERROR_USER_NO_ACCESS_VARIABLE=Le joueur n'a pas accès à cette variable\!
-ERROR_USER_NO_ACCESS_VARIABLE_DIRECT=Le joueur n'a pas d'accès direct à cette variable\!
+ERROR_USER_NO_ACCESS_PERMISSION=Le joueur n'a pas accÃ¨s Ã  cette permission.
+ERROR_USER_NO_ACCESS_PERMISSION_DIRECT=Le joueur n'a pas d'accÃ¨s direct Ã  cette permission.
+ERROR_GROUP_NO_ACCESS_PERMISSION=Le groupe n'a pas accÃ¨s Ã  cette permission.
+ERROR_GROUP_NO_ACCESS_PERMISSION_DIRECT=Le groupe n'a pas d'accÃ¨s direct Ã  cette permission.
+ERROR_GROUP_NO_ACCESS_VARIABLE=Le groupe n'a pas accÃ¨s Ã  cette variable\!
+ERROR_GROUP_NO_ACCESS_VARIABLE_DIRECT=Le groupe n'a pas d'accÃ¨s direct Ã  cette variable\!
+ERROR_USER_NO_ACCESS_VARIABLE=Le joueur n'a pas accÃ¨s Ã  cette variable\!
+ERROR_USER_NO_ACCESS_VARIABLE_DIRECT=Le joueur n'a pas d'accÃ¨s direct Ã  cette variable\!
 
-VARIABLE_REMOVED_FROM_USER=Variable %s retirée au joueur %s.
-VARIABLE_REMOVED_FROM_GROUP=Variable %s retirée au groupe %s.
-VARIABLE_ADDED_TO_USER=Variable %s:'%s' ajoutée au joueur %s.
-VARIABLE_ADDED_TO_GROUP=Variable %s:'%s' ajoutée au groupe %s.
+VARIABLE_REMOVED_FROM_USER=Variable %s retirÃ©e au joueur %s.
+VARIABLE_REMOVED_FROM_GROUP=Variable %s retirÃ©e au groupe %s.
+VARIABLE_ADDED_TO_USER=Variable %s:'%s' ajoutÃ©e au joueur %s.
+VARIABLE_ADDED_TO_GROUP=Variable %s:'%s' ajoutÃ©e au groupe %s.
 VARIABLE_VALUE=La valeur de la variable '%s' est: '%s'.
-VARIABLE_INHERITED=et la valeur a été héritée du groupe: 
+VARIABLE_INHERITED=et la valeur a Ã©tÃ© hÃ©ritÃ©e du groupe: 
 VARIABLES_OF_GROUP=Variables du groupe %s: 
 VARIABLES_OF_USER=Variables du joueur %s: 
 VARIABLES_ALL_GROUPS=Plus toutes les variables des groupes: %s
 
-SUBGROUP_ADDED_USER=Vous avez ajouté le sous-groupe '%s' au joueur '%s'.
-SUBGROUP_ADDED_USER_TIMED=Vous avez ajouté le sous-groupe '%s' au joueur '%s' pour une durée de %d minutes.
-SUBGROUP_REMOVED_USER=Vous avez retiré le sous-groupe '%s' au joueur '%s'.
-ERROR_SUBGROUP_ALREADY_AVAILABLE=Le sous-groupe '%s' est déjà valable pour '%s'.
+SUBGROUP_ADDED_USER=Vous avez ajoutÃ© le sous-groupe '%s' au joueur '%s'.
+SUBGROUP_ADDED_USER_TIMED=Vous avez ajoutÃ© le sous-groupe '%s' au joueur '%s' pour une durÃ©e de %d minutes.
+SUBGROUP_REMOVED_USER=Vous avez retirÃ© le sous-groupe '%s' au joueur '%s'.
+ERROR_SUBGROUP_ALREADY_AVAILABLE=Le sous-groupe '%s' est dÃ©jÃ  valable pour '%s'.
 AND_ALL_PERMISSIONS_GROUPS=Et toutes les permissions des groupes: %s
 AND_ALL_PERMISSIONS_SUBGROUPS=Et toutes les permissions des sous-groupes: %s
 GROUP_HAS_PERMISSIONS=Le groupe '%s' a les permissions suivantes: %s
 USER_HAS_PERMISSIONS=Le joueur '%s' a les permissions suivantes: %s
 GROUP_NO_SPECIFIC_PERMISSIONS=Le groupe '%s' n'a pas de permissions directes.
 USER_NO_SPECIFIC_PERMISSIONS=Le joueur '%s' n'a pas de permissions directes.
-ERROR_SAME_PERMISSIONS_OR_HIGHER=Vous ne pouvez pas modifier un joueur avec les mêmes permissions que vous, ou supérieures.
-ERROR_SAME_GROUP_OR_HIGHER=Vous ne pouvez pas modifier un joueur avec le même groupe que vous, ou supérieur.
-ERROR_DIFFERENT_INHERITANCE_LINES=Vous ne pouvez pas modifier un joueur utilisant un groupe avec différents héritages.
-ERROR_DESTINATION_HIGHER_THAN_YOURS=Le groupe de destination ne peut pas être le même que le vôtre, ni supérieur.
-ERROR_SUBGROUP_HIGHER_THAN_YOURS=Le sous-groupe ne peut pas être le même que le vôtre, ni supérieur.
-ERROR_NEW_GROUP_NOT_HIGHER=Le nouveau groupe doit être supérieur à celui actuel.
-ERROR_NEW_GROUP_NOT_LOWER=Le nouveau groupe doit être inférieur à celui actuel.
-ERROR_PLAYERS_NOT_MEMBERS_OF_GG=Joueurs ne peuvent être membres des GlobalGroups directement.
-ERROR_YOU_DO_NOT_INHERIT=Vous ne pouvez modifier un joueur incluant un groupe que dont vous n'héritez pas.
+ERROR_SAME_PERMISSIONS_OR_HIGHER=Vous ne pouvez pas modifier un joueur avec les mÃªmes permissions que vous, ou supÃ©rieures.
+ERROR_SAME_GROUP_OR_HIGHER=Vous ne pouvez pas modifier un joueur avec le mÃªme groupe que vous, ou supÃ©rieur.
+ERROR_DIFFERENT_INHERITANCE_LINES=Vous ne pouvez pas modifier un joueur utilisant un groupe avec diffÃ©rents hÃ©ritages.
+ERROR_DESTINATION_HIGHER_THAN_YOURS=Le groupe de destination ne peut pas Ãªtre le mÃªme que le vÃ´tre, ni supÃ©rieur.
+ERROR_SUBGROUP_HIGHER_THAN_YOURS=Le sous-groupe ne peut pas Ãªtre le mÃªme que le vÃ´tre, ni supÃ©rieur.
+ERROR_NEW_GROUP_NOT_HIGHER=Le nouveau groupe doit Ãªtre supÃ©rieur Ã  celui actuel.
+ERROR_NEW_GROUP_NOT_LOWER=Le nouveau groupe doit Ãªtre infÃ©rieur Ã  celui actuel.
+ERROR_PLAYERS_NOT_MEMBERS_OF_GG=Joueurs ne peuvent Ãªtre membres des GlobalGroups directement.
+ERROR_YOU_DO_NOT_INHERIT=Vous ne pouvez modifier un joueur incluant un groupe que dont vous n'hÃ©ritez pas.
 ERROR_CANT_REMOVE_PERMISSION=Vous ne pouvez pas retirer une permission que vous n'avez pas: '%s'
 ERROR_CANT_ADD_PERMISSION=Vous ne pouvez pas ajouter une permission que vous n'avez pas: '%s'
 
-ERROR_BUKKIT_INVALID_ARGUMENTS=Bukkit a donné un tableau d'arguments non-valables \! Cmd: %s args.length: %d
-ERROR_UNABLE_TO_SAVE=Impossible de sauvegarder à moins que vous utilisiez '/mansave force'
+ERROR_BUKKIT_INVALID_ARGUMENTS=Bukkit a donnÃ© un tableau d'arguments non-valables \! Cmd: %s args.length: %d
+ERROR_UNABLE_TO_SAVE=Impossible de sauvegarder Ã  moins que vous utilisiez '/mansave force'
 
 WORLDS_AVAILABLE=Mondes valables: 
-YOU_HAVE_SELECTED_WORLD=Vous avez sélectionné le monde '%s'.
-NO_WORLD_AVAILABLE=Aucun monde sélectionné, et aucun monde valable pour le moment.
-NO_WORLD_SELECTED=Vous n'avez pas sélectionné un monde.
-USING_WORLD=Fonctionne avec le monde où le joueur se trouve.
-USING_PERMISSIONS_OF_WORLD=Votre monde utilise désormais les permissions du monde: '%s'
-NEGATED=\ (Annulée)
+YOU_HAVE_SELECTED_WORLD=Vous avez sÃ©lectionnÃ© le monde '%s'.
+NO_WORLD_AVAILABLE=Aucun monde sÃ©lectionnÃ©, et aucun monde valable pour le moment.
+NO_WORLD_SELECTED=Vous n'avez pas sÃ©lectionnÃ© un monde.
+USING_WORLD=Fonctionne avec le monde oÃ¹ le joueur se trouve.
+USING_PERMISSIONS_OF_WORLD=Votre monde utilise dÃ©sormais les permissions du monde: '%s'
+NEGATED=\ (AnnulÃ©e)
 SUPER_PERMS_REPORTS=SuperPerms rapporte noeud: 
 USER_HAS_EXCEPTION_DIRECT=Le joueur a une exception directe pour la permission.
-USER_HAS_NEGATION_DIRECT=Le joueur a une négation directe pour la permission.
-USER_HAS_PERMISSION_DIRECT=Le joueur possède directement cette permission.
-USER_HAS_VARIABLE_DIRECT=Le joueur possède directement cette variable.
-USER_INHERITS_EXCEPTION_FROM_GROUP=Le joueur hérite de l'exception d'une permission du groupe: 
-USER_INHERITS_NEGATION_FROM_GROUP=Le joueur hérite d'une négation d'une permission du groupe: 
-USER_INHERITS_PERMISSION_FROM_GROUP=Le joueur hérite de la permission du groupe: 
-GROUP_INHERITS_NEGATION_FROM_GROUP=Le groupe hérite d'une négation d'une permission du groupe: 
-GROUP_INHERITS_EXCEPTION_FROM_GROUP=Le groupe hérite de l'exception d'une permission du groupe: 
+USER_HAS_NEGATION_DIRECT=Le joueur a une nÃ©gation directe pour la permission.
+USER_HAS_PERMISSION_DIRECT=Le joueur possÃ¨de directement cette permission.
+USER_HAS_VARIABLE_DIRECT=Le joueur possÃ¨de directement cette variable.
+USER_INHERITS_EXCEPTION_FROM_GROUP=Le joueur hÃ©rite de l'exception d'une permission du groupe: 
+USER_INHERITS_NEGATION_FROM_GROUP=Le joueur hÃ©rite d'une nÃ©gation d'une permission du groupe: 
+USER_INHERITS_PERMISSION_FROM_GROUP=Le joueur hÃ©rite de la permission du groupe: 
+GROUP_INHERITS_NEGATION_FROM_GROUP=Le groupe hÃ©rite d'une nÃ©gation d'une permission du groupe: 
+GROUP_INHERITS_EXCEPTION_FROM_GROUP=Le groupe hÃ©rite de l'exception d'une permission du groupe: 
 GROUP_INHERITS_PERMISSION_FROM_GROUP=The group inherits the permission from group: 
-ERROR_REVIEW_ARGUMENTS=Vérifier votre nombre d'arguments \!
-USER_CHANGED_TO_DEFAULT=Vous avez changé le jouuer '%s' pour les paramètres par défaut.
-USER_CHANGED_TO_GROUP=Vous avez gagné le groupe de '%s' pour le groupe '%s' dans le monde'%s'.
-REMOVED_PERMISSION_FROM_PLAYER=Vous avez retiré la permission '%s' de la liste des permissions de '%s'.
-REMOVED_ALL_PERMISSIONS_PLAYER=Vous avez retiré toutes les permissions de: %s
-REMOVED_ALL_PERMISSIONS_GROUP=Vous avez retiré toutes les permissions du groupe: %s
-REMOVED_PERMISSION_FROM_GROUP=Vous avez retiré la permission '%s' des permissions du groupe '%s'.
-ADDED_PERMISSION_TO_GROUP=Vous avez ajouté la permission '%s' aux permissions du groupe '%s'.
-ADDED_PERMISSION_TO_GROUP_TIMED=Vous avez ajouté la permission '%s' aux permissions du groupe '%s' pour une durée de %d minutes.
-ADDED_PERMISSION_TO_USER=Vous avez ajouté la permission '%s' aux permissions de '%s'.
-ADDED_PERMISSION_TO_USER_TIMED=Vous avez ajouté la permission '%s' aux permissions de '%s' pour une durée de %d minutes.
-ERROR_NO_MATCHING_PERMISSION_NODE=Cette permission ne correspond à aucune autre.
-ERROR_INVALID_DURATION=Durée invalide avec : '%s'
+ERROR_REVIEW_ARGUMENTS=VÃ©rifier votre nombre d'arguments \!
+USER_CHANGED_TO_DEFAULT=Vous avez changÃ© le jouuer '%s' pour les paramÃ¨tres par dÃ©faut.
+USER_CHANGED_TO_GROUP=Vous avez gagnÃ© le groupe de '%s' pour le groupe '%s' dans le monde'%s'.
+REMOVED_PERMISSION_FROM_PLAYER=Vous avez retirÃ© la permission '%s' de la liste des permissions de '%s'.
+REMOVED_ALL_PERMISSIONS_PLAYER=Vous avez retirÃ© toutes les permissions de: %s
+REMOVED_ALL_PERMISSIONS_GROUP=Vous avez retirÃ© toutes les permissions du groupe: %s
+REMOVED_PERMISSION_FROM_GROUP=Vous avez retirÃ© la permission '%s' des permissions du groupe '%s'.
+ADDED_PERMISSION_TO_GROUP=Vous avez ajoutÃ© la permission '%s' aux permissions du groupe '%s'.
+ADDED_PERMISSION_TO_GROUP_TIMED=Vous avez ajoutÃ© la permission '%s' aux permissions du groupe '%s' pour une durÃ©e de %d minutes.
+ADDED_PERMISSION_TO_USER=Vous avez ajoutÃ© la permission '%s' aux permissions de '%s'.
+ADDED_PERMISSION_TO_USER_TIMED=Vous avez ajoutÃ© la permission '%s' aux permissions de '%s' pour une durÃ©e de %d minutes.
+ERROR_NO_MATCHING_PERMISSION_NODE=Cette permission ne correspond Ã  aucune autre.
+ERROR_INVALID_DURATION=DurÃ©e invalide avec : '%s'
 PERMISSION_NODE=Permission : %s
-POSSIBLE_MATCH=Mais pourrait correspondre à : %s
-RELOAD_REQUEST_ATTEMPT=La requête de rechargée le monde '%s' a été demandée.
-RELOADED=Tous les paramètres et mondes ont été rechargés \!
+POSSIBLE_MATCH=Mais pourrait correspondre Ã  : %s
+RELOAD_REQUEST_ATTEMPT=La requÃªte de rechargÃ©e le monde '%s' a Ã©tÃ© demandÃ©e.
+RELOADED=Tous les paramÃ¨tres et mondes ont Ã©tÃ© rechargÃ©s \!
 
-AUTOSAVE_ENABLE=Sauvegarde automatique est activée\!
-AUTOSAVE_DISABLE=Sauvegarde automatique est désactivée\! Permissions temporairement n'expireront jamais si la sauvegarde est désactivée \!
-VALIDATE_STATUS=Valider si un joueur est en ligne, maintenant défini sur: 
-VALIDATE_1=Pour le moment vous pouvez éditer un joueur hors ligne... MAIS:
+AUTOSAVE_ENABLE=Sauvegarde automatique est activÃ©e\!
+AUTOSAVE_DISABLE=Sauvegarde automatique est dÃ©sactivÃ©e\! Permissions temporairement n'expireront jamais si la sauvegarde est dÃ©sactivÃ©e \!
+VALIDATE_STATUS=Valider si un joueur est en ligne, maintenant dÃ©fini sur: 
+VALIDATE_1=Pour le moment vous pouvez Ã©diter un joueur hors ligne... MAIS:
 VALIDATE_2=Vous devez taper le pseudonyme entier du joueur, correctement.
 
 # ManWhois text elements.
 NAME=Nom: 
 GROUP=Groupe: 
 SUBGROUPS=Sous-groupes: 
-OVERLOADED=Surchargé: 
+OVERLOADED=SurchargÃ©: 
 ORIGINAL_GROUP=Groupe Original: 
 
 # ManCheckW text elements
-WORLD_USING_DATA_FILES=Ce monde utilise actuellement le fichier de données actuel...
+WORLD_USING_DATA_FILES=Ce monde utilise actuellement le fichier de donnÃ©es actuel...
 GROUPS=Groupes: 
 USERS=Utilisateurs: 
 
@@ -119,122 +119,122 @@ GROUPS_AVAILABLE=Groupes Valables:
 GG_AVALIABLE=GlobalGroups Valables: 
 
 # Temp Commands text elements.
-PLAYER_OVERLOADED=Joueur mis sur le mode surchargé \!
-OVERLOAD_DISABLED=Mode surcharge des joueurs désactivé.
+PLAYER_OVERLOADED=Joueur mis sur le mode surchargÃ© \!
+OVERLOAD_DISABLED=Mode surcharge des joueurs dÃ©sactivÃ©.
 NO_OVERLOAD=Il n'y a aucun joueur en mode surcharge.
-EMPTY_OVERLOAD=Tous les joueurs en mode surcharge sont remis à la normal.
+EMPTY_OVERLOAD=Tous les joueurs en mode surcharge sont remis Ã  la normal.
 OVERLOADED_USERS=Il y a (%d) joueurs en mode surcharge: 
 
 # BaseCommand text elements.
-COMMAND_BLOCKS=Commandes de GroupManager ne peuvent être utilisées dans un bloc de commandes
+COMMAND_BLOCKS=Commandes de GroupManager ne peuvent Ãªtre utilisÃ©es dans un bloc de commandes
 LOCATION=Localisation: 
-COMMAND_ERROR=Toutes les commandes désactivées à cause d'une erreur. Chequez plugins/groupmanager/error.log ou la console et essayez un '/manload'.
-COMMAND_NOT_PERMITTED=Vous n'êtes pas autorisé à utiliser cette commande.
-DEFAULT_WORLD_SELECTED=Impossible de trouver votre monde. Monde par défaut '%s' sélectionné.
-WORLD_SELECTION_NEEDED=Impossible de trouver votre monde. La sélection d'un monde est demandée.
+COMMAND_ERROR=Toutes les commandes dÃ©sactivÃ©es Ã  cause d'une erreur. Chequez plugins/groupmanager/error.log ou la console et essayez un '/manload'.
+COMMAND_NOT_PERMITTED=Vous n'Ãªtes pas autorisÃ© Ã  utiliser cette commande.
+DEFAULT_WORLD_SELECTED=Impossible de trouver votre monde. Monde par dÃ©faut '%s' sÃ©lectionnÃ©.
+WORLD_SELECTION_NEEDED=Impossible de trouver votre monde. La sÃ©lection d'un monde est demandÃ©e.
 USE_MANSELECT=Use /manselect <monde>
-PLAYER_NOT_FOUND=Joueur introuvé \!
-TOO_MANY_MATCHES=Trop de similarités trouvées \!
+PLAYER_NOT_FOUND=Joueur introuvÃ© \!
+TOO_MANY_MATCHES=Trop de similaritÃ©s trouvÃ©es \!
 
 # Notify text elements.
-PLAYER_WAS=\ a été
-YOU_WERE=Vous avez été
-MOVED_TO_GROUP=\ déplacé dans le groupe %s dans le monde %s.
+PLAYER_WAS=\ a Ã©tÃ©
+YOU_WERE=Vous avez Ã©tÃ©
+MOVED_TO_GROUP=\ dÃ©placÃ© dans le groupe %s dans le monde %s.
 
 # WorldDataHolder
 WorldDatHolder.ERROR_NO_GROUPS_FILE=Le fichier qui doit contenir les groups n'existe pas\!
 WorldDatHolder.ERROR_ACCESSING_GROUPS_FILE=Erreur pour attendre le fichier des groupes\!
 WorldDatHolder.ERROR_NO_USERS_FILE=Le fichier qui doit contenir les utilisateurs n'existe pas\!
 WorldDatHolder.ERROR_ACCESSING_USERS_FILE=Erreur pour attendre le fichier des utilisateurs\!
-WorldDatHolder.ERROR_INVALID_FILE=Votre fichier %s est invalide. Regardez la console pour les détails.
+WorldDatHolder.ERROR_INVALID_FILE=Votre fichier %s est invalide. Regardez la console pour les dÃ©tails.
 WorldDatHolder.ERROR_NO_GROUPS=Aucun groupe dans %s
 WorldDatHolder.ERROR_INVALID_GROUP_NAME=Nom de groupe invalide pour '%s' dans le fichier: %s
 WorldDatHolder.ERROR_INVALID_CHILD_NODE=Mauvais parentage pour '%s' dans le fichier: %s
-WorldDatHolder.ERROR_GROUP_DUPLICATE=Ce groupe a été déclaré plus d'une fois: %s dans le fichier: %s
+WorldDatHolder.ERROR_GROUP_DUPLICATE=Ce groupe a Ã©tÃ© dÃ©clarÃ© plus d'une fois: %s dans le fichier: %s
 WorldDatHolder.ERROR_INVALID_FORMAT=Mauvais formatage de groupe dans '%s' pour le groupe: %s dans le fichier: %s
-WorldDatHolder.ERROR_DEFAULT_DUPLICATE=Le groupe '%s' se dit être le groupe par défaut alors que '%s' l'était déjà.
-WorldDatHolder.WARN_OVERIDE_DEFAULT=Remplace la première demande de groupe par défaut dans le fichier: %s
-WorldDatHolder.ERROR_UNKNOWN_TYPE=Type de paramètre inconnu pour '%s' (Devrait être String ou List<String>) pour le groupe: %s dans le fichier: %s
-WorldDatHolder.ERROR_UNKNOWN_ENTRY=Entrée inconnue trouvée dans '%s' pour le groupe: %s dans le fichier: %s
+WorldDatHolder.ERROR_DEFAULT_DUPLICATE=Le groupe '%s' se dit Ãªtre le groupe par dÃ©faut alors que '%s' l'Ã©tait dÃ©jÃ .
+WorldDatHolder.WARN_OVERIDE_DEFAULT=Remplace la premiÃ¨re demande de groupe par dÃ©faut dans le fichier: %s
+WorldDatHolder.ERROR_UNKNOWN_TYPE=Type de paramÃ¨tre inconnu pour '%s' (Devrait Ãªtre String ou List<String>) pour le groupe: %s dans le fichier: %s
+WorldDatHolder.ERROR_UNKNOWN_ENTRY=EntrÃ©e inconnue trouvÃ©e dans '%s' pour le groupe: %s dans le fichier: %s
 WorldDatHolder.WARN_GROUP_NO_INFO=Le groupe '%s' n'a pas de section 'info' \!
-WorldDatHolder.WARN_USING_DEFAULT=Utilisation des valeurs par défaut: 
-WorldDatHolder.ERROR_NO_DEFAULT=Aucun groupe par défaut nommé dans le fichier: %s
-WorldDatHolder.WARN_INHERITED_NOT_FOUND=Groupe d'héritage '%s' non trouvé pour le groupe %s. Ignore l'entrée dans le fichier: %s
-WorldDatHolder.ERROR_INVALID_NODE_USER=Paramètre invalide pour l'entrée #(%d) dans le fichier: %s
-WorldDatHolder.ERROR_INVALID_FORMAT_FOR_USER=Formatage invalide trouvé pour l'utilisateur: %s dans le fichier: %s
-WorldDatHolder.ERROR_DUPLICATE_USER=Utilisateur déclaré plus d'une fois: %s dans le fichier: %s
-WorldDatHolder.ERROR_INVALID_FORMAT_IN_USER=Formatage invalide trouvé dans '%s' pour l'utilisateur: %s dans le fichier: %s
-WorldDatHolder.ERROR_UNKNOWN_ENTRY_USER=Entrée inconnue trouvée '%s' pour l'utilisateur: %s dans le fichier: %s
-WorldDatHolder.WARN_NO_GROUP_STATED=Il n'y a pas de groupe %s, comme indiqué pour le joueur %s: Mis sur '%s' dans le fichier: %s
-WorldDatHolder.WARN_INVALID_SUBGROUP=Sous-groupe invalide: %s. Entrée ignorée dans le fichier: %s
-WorldDatHolder.WARN_SUBGROUP_NOT_FOUND=Sous-groupe '%s' non-trouvé pour l'utilisateur: %s. Entrée ignorée dans le fichier: %s
-WorldDatHolder.WARN_NO_DEFAULT_GROUP=Aucun groupe par défaut pour le monde: 
+WorldDatHolder.WARN_USING_DEFAULT=Utilisation des valeurs par dÃ©faut: 
+WorldDatHolder.ERROR_NO_DEFAULT=Aucun groupe par dÃ©faut nommÃ© dans le fichier: %s
+WorldDatHolder.WARN_INHERITED_NOT_FOUND=Groupe d'hÃ©ritage '%s' non trouvÃ© pour le groupe %s. Ignore l'entrÃ©e dans le fichier: %s
+WorldDatHolder.ERROR_INVALID_NODE_USER=ParamÃ¨tre invalide pour l'entrÃ©e #(%d) dans le fichier: %s
+WorldDatHolder.ERROR_INVALID_FORMAT_FOR_USER=Formatage invalide trouvÃ© pour l'utilisateur: %s dans le fichier: %s
+WorldDatHolder.ERROR_DUPLICATE_USER=Utilisateur dÃ©clarÃ© plus d'une fois: %s dans le fichier: %s
+WorldDatHolder.ERROR_INVALID_FORMAT_IN_USER=Formatage invalide trouvÃ© dans '%s' pour l'utilisateur: %s dans le fichier: %s
+WorldDatHolder.ERROR_UNKNOWN_ENTRY_USER=EntrÃ©e inconnue trouvÃ©e '%s' pour l'utilisateur: %s dans le fichier: %s
+WorldDatHolder.WARN_NO_GROUP_STATED=Il n'y a pas de groupe %s, comme indiquÃ© pour le joueur %s: Mis sur '%s' dans le fichier: %s
+WorldDatHolder.WARN_INVALID_SUBGROUP=Sous-groupe invalide: %s. EntrÃ©e ignorÃ©e dans le fichier: %s
+WorldDatHolder.WARN_SUBGROUP_NOT_FOUND=Sous-groupe '%s' non-trouvÃ© pour l'utilisateur: %s. EntrÃ©e ignorÃ©e dans le fichier: %s
+WorldDatHolder.WARN_NO_DEFAULT_GROUP=Aucun groupe par dÃ©faut pour le monde: 
 
 # WorldsHolder
 WorldsHolder.ADDING_GROUPS_MIRROR=Ajout du mirroir des groupes pour %s.
 WorldsHolder.ADDING_USERS_MIRROR=Ajout du mirroir des utilisateurs pour %s
 WorldsHolder.ATTEMPT_TO_LOAD=Essaie de charger le monde %s...
-WorldsHolder.CHECKING_DATA=Cherche données pour %s.
-WorldsHolder.CREATING_FOLDERS=Création d'un dossier pour %s.
-WorldsHolder.ERROR_NO_DEFAULT_GROUP=Il n'y pas de groupe par défaut\!
+WorldsHolder.CHECKING_DATA=Cherche donnÃ©es pour %s.
+WorldsHolder.CREATING_FOLDERS=CrÃ©ation d'un dossier pour %s.
+WorldsHolder.ERROR_NO_DEFAULT_GROUP=Il n'y pas de groupe par dÃ©faut\!
 WorldsHolder.ERROR_NO_GROUPS_FILE=Fichier des groupes pour le monde '%s' n'existe pas: %s
 WorldsHolder.ERROR_NO_USERS_FILE=Fichier des utilisateurs pour le monde '%s' n'existe pas: %s
-WorldsHolder.MIRRORING_ERROR=Erreur de mirroir %s. Boucle récursive détectée\!
-WorldsHolder.NEWER_GROUPS_FILE_LOADING=Fichier de groupes plus récent détecté (Chargement des changements)\!
-WorldsHolder.NEWER_USERS_FILE_LOADING=Fichier d'utilisateurs plus récent détecté (Chargement des changements)\!
-WorldsHolder.NO_DATA=Pas de données pour %s.
+WorldsHolder.MIRRORING_ERROR=Erreur de mirroir %s. Boucle rÃ©cursive dÃ©tectÃ©e\!
+WorldsHolder.NEWER_GROUPS_FILE_LOADING=Fichier de groupes plus rÃ©cent dÃ©tectÃ© (Chargement des changements)\!
+WorldsHolder.NEWER_USERS_FILE_LOADING=Fichier d'utilisateurs plus rÃ©cent dÃ©tectÃ© (Chargement des changements)\!
+WorldsHolder.NO_DATA=Pas de donnÃ©es pour %s.
 WorldsHolder.UNKNOWN_MIRRORING_FORMAT=Format de mirroir inconnu pour %s
-WorldsHolder.WARN_NEWER_GROUPS_FILE_UNABLE=Fichier de groupes plus récent trouvé pour %s, mais il y a des changements locaux\!
-WorldsHolder.WARN_NEWER_USERS_FILE_UNABLE=Fichier d'utilisateurs plus récent trouvé pour %s, mais il y a des changements locaux\!
+WorldsHolder.WARN_NEWER_GROUPS_FILE_UNABLE=Fichier de groupes plus rÃ©cent trouvÃ© pour %s, mais il y a des changements locaux\!
+WorldsHolder.WARN_NEWER_USERS_FILE_UNABLE=Fichier d'utilisateurs plus rÃ©cent trouvÃ© pour %s, mais il y a des changements locaux\!
 WorldsHolder.WHAT_HAPPENED=QUE S'EST-IL PASSE?
-WorldsHolder.WORLD_FOUND=Monde trouvé: %s
-WorldsHolder.WORLD_LOAD_SUCCESS=Chargement du monde %s réussi...
-WorldsHolder.WORLD_NOT_FOUND_DEFAULT=Le monde %s n'a pas été trouvé ou mal paramètré. Retour sur le monde par défault...
-WorldsHolder.WORLD_NOT_FOUND_UNNAMED=Le monde %s n'a pas été trouvé ou mal paramètré. Retour sur all_unnamed_worlds...
+WorldsHolder.WORLD_FOUND=Monde trouvÃ©: %s
+WorldsHolder.WORLD_LOAD_SUCCESS=Chargement du monde %s rÃ©ussi...
+WorldsHolder.WORLD_NOT_FOUND_DEFAULT=Le monde %s n'a pas Ã©tÃ© trouvÃ© ou mal paramÃ¨trÃ©. Retour sur le monde par dÃ©fault...
+WorldsHolder.WORLD_NOT_FOUND_UNNAMED=Le monde %s n'a pas Ã©tÃ© trouvÃ© ou mal paramÃ¨trÃ©. Retour sur all_unnamed_worlds...
 
 # GlobalGroups Text
-GlobalGroups.BAD_FORMATTED=Le GlobalGroup '%s' est formaté incorrectement. 
-GlobalGroups.ERROR_NEWER_GG_FOUND=Un fichier de GlobalGroups plus recent a été trouvé, mais nous avons des changements locaux\!
-GlobalGroups.INVALID_GROUP_NAME=Nom de groupe invalide pour l'entrée du GlobalGroup \#[%d] dans le fichier: %s
+GlobalGroups.BAD_FORMATTED=Le GlobalGroup '%s' est formatÃ© incorrectement. 
+GlobalGroups.ERROR_NEWER_GG_FOUND=Un fichier de GlobalGroups plus recent a Ã©tÃ© trouvÃ©, mais nous avons des changements locaux\!
+GlobalGroups.INVALID_GROUP_NAME=Nom de groupe invalide pour l'entrÃ©e du GlobalGroup \#[%d] dans le fichier: %s
 GlobalGroups.INVALID_PERMISSION_NODE=Permission invalide dans le groupe global: %s
 GlobalGroups.UNKNOWN_PERMISSION_TYPE=Type de permission inconnu dans le groupe global: %s
-GlobalGroups.WARN_NEWER_GG_FOUND_LOADING=Un fichier GlobalGroup plus récent a été trouvé (Chargement des changements)\!
+GlobalGroups.WARN_NEWER_GG_FOUND_LOADING=Un fichier GlobalGroup plus rÃ©cent a Ã©tÃ© trouvÃ© (Chargement des changements)\!
 
 # Config text.
-GMConfiguration.CORRUPT_NODE=Noeud '%s' manquant ou corrompu. Utilisation des paramètres par défaut
-GMConfiguration.ERROR_CREATING_CONFIG=Erreur pour créer un nouveau config.yml
-GMConfiguration.ERRORS_IN_CONFIG=Il y a des erreurs dans votre config.yml. Utilisation des paramètres par défaut.
+GMConfiguration.CORRUPT_NODE=Noeud '%s' manquant ou corrompu. Utilisation des paramÃ¨tres par dÃ©faut
+GMConfiguration.ERROR_CREATING_CONFIG=Erreur pour crÃ©er un nouveau config.yml
+GMConfiguration.ERRORS_IN_CONFIG=Il y a des erreurs dans votre config.yml. Utilisation des paramÃ¨tres par dÃ©faut.
 GMConfiguration.MISSING_NODE=Le config.yml n'a pas '%s'.
 
 GroupManager.BACKUPS_RETAINED_MSG=Sauvegardes seront retenues pendant %d heures\!
 GroupManager.CANT_ENABLE=Nous nous pouvons activer %s version %s, mauvais chargement\!
-GroupManager.DISABLED=Version %s est désactivée\!
-GroupManager.ENABLED=Version %s est activée\!
+GroupManager.DISABLED=Version %s est dÃ©sactivÃ©e\!
+GroupManager.ENABLED=Version %s est activÃ©e\!
 GroupManager.ERROR_LOADING=Une erreur est apparue lors du chargement de GroupManager
-GroupManager.ERROR_SCHEDULING_SUPERPERMS=Impossible de programmer les mises à jours de superperms.
+GroupManager.ERROR_SCHEDULING_SUPERPERMS=Impossible de programmer les mises Ã  jours de superperms.
 GroupManager.FILE_CORRUPT=Le fichier suivant est corrompu: %s
-GroupManager.PERMISSION_DIRECT_ACCESS=Le %s a déjà accès à cette permission.
-GroupManager.PERMISSION_DIRECT_ACCESS_ALREADY=Le %s a déjà accès à cette permission.
-GroupManager.PERMISSION_EXCEPTION=Le %s possède déjà une exception pour cette permission.
-GroupManager.PERMISSION_EXCEPTION_ALREADY=Le %s possède déjà une exception pour cette permission.
-GroupManager.PERMISSION_MATCHING_NEGATION=Le %s a déjà une permission négative correspondante.
-GroupManager.PERMISSION_MATCHING_NEGATION_ALREADY=Le %s a déjà une permission négative correspondante.
+GroupManager.PERMISSION_DIRECT_ACCESS=Le %s a dÃ©jÃ  accÃ¨s Ã  cette permission.
+GroupManager.PERMISSION_DIRECT_ACCESS_ALREADY=Le %s a dÃ©jÃ  accÃ¨s Ã  cette permission.
+GroupManager.PERMISSION_EXCEPTION=Le %s possÃ¨de dÃ©jÃ  une exception pour cette permission.
+GroupManager.PERMISSION_EXCEPTION_ALREADY=Le %s possÃ¨de dÃ©jÃ  une exception pour cette permission.
+GroupManager.PERMISSION_MATCHING_NEGATION=Le %s a dÃ©jÃ  une permission nÃ©gative correspondante.
+GroupManager.PERMISSION_MATCHING_NEGATION_ALREADY=Le %s a dÃ©jÃ  une permission nÃ©gative correspondante.
 GroupManager.PERMISSION_NODE=Permission: 
-GroupManager.REFRESHED=Fichiers de donnés rafraîchis.
-GroupManager.SCHEDULED_DATA_SAVING_DISABLED=Programmation de sauvegarde des données désactivée\!
-GroupManager.SCHEDULED_DATA_SAVING_SET=Programmation de sauvegarde des données prévue toutes les %d minutes\!
+GroupManager.REFRESHED=Fichiers de donnÃ©s rafraÃ®chis.
+GroupManager.SCHEDULED_DATA_SAVING_DISABLED=Programmation de sauvegarde des donnÃ©es dÃ©sactivÃ©e\!
+GroupManager.SCHEDULED_DATA_SAVING_SET=Programmation de sauvegarde des donnÃ©es prÃ©vue toutes les %d minutes\!
 
 # Tasks
-BukkitPermsUpdateTask.BUKKIT_PERMISSIONS_UPDATED=Permissions BUKKIT mises à jour\!
-UpdateTask.ERROR_PARSING_VERSION=Il y a eu une erreur lorsque nous cherchions le paramètre de version.
-UpdateTask.ERROR_VERSION_CHECKING=Erreur lors de la recherche d'une mise à jour.
+BukkitPermsUpdateTask.BUKKIT_PERMISSIONS_UPDATED=Permissions BUKKIT mises Ã  jour\!
+UpdateTask.ERROR_PARSING_VERSION=Il y a eu une erreur lorsque nous cherchions le paramÃ¨tre de version.
+UpdateTask.ERROR_VERSION_CHECKING=Erreur lors de la recherche d'une mise Ã  jour.
 UpdateTask.UPDATE_AVAILABLE=Nouvelle version: %s disponible\! Vous utilisez la version: %s
 UpdateTask.WE_ARE_UP_TO_DATE=Pas de nouvelles versions
 
 # GMWorldListener
 GMWorldListener.CONFIGURE_NEW_WORLD=N'oubliez pas de configurer ce monde dans config.yml.
-GMWorldListener.CREATING_DATA=Création de données pour: 
-GMWorldListener.DETECTED_NEW_WORLD=Nouveau monde détecté...
+GMWorldListener.CREATING_DATA=CrÃ©ation de donnÃ©es pour: 
+GMWorldListener.DETECTED_NEW_WORLD=Nouveau monde dÃ©tectÃ©...
 GMWorldListener.ERROR_UNRECOGNISED_WORLD=Impossible de configurer ce monde.
 
 # Command Syntax


### PR DESCRIPTION
### What is that ?
I saw that the french localization isn't saved with UTF-8.
I give you the opportunity to merge this with the UTF-8 encoded `french.properties`.

You can see that even GitHub sees the difference between ANSI and UTF-8.

It's just in case you want to merge it.

### The Initial Bug Report (that i don't sent it because i prefer doing things to save time).

**Description**
Encoding UTF-8 for French language is very important. Can give us our éèàïî symbols that Minecraft doesn't like without UTF-8.

**Steps to reproduce**
1. Go to config.yml
2. Change language to French
3. See the errors.

**Expected behavior**
![image](https://user-images.githubusercontent.com/68754021/187102499-9a00b4f2-8c4d-4c97-8e1b-82b236c4e5cd.png)

**Screenshots**
![image](https://user-images.githubusercontent.com/68754021/187102275-093a9d98-85ea-4a21-9c41-1f2c9ee28b61.png)

**Please complete the following information:**
 - OS: The server maybe running Linux, on a french Minecraft Hosting Provider.
 - PaperMC-81 (latest version in 1.19.2)
 - GroupManager version 2.9 (Phoenix)